### PR TITLE
Decrease build time

### DIFF
--- a/base-portable/build.gradle
+++ b/base-portable/build.gradle
@@ -3,6 +3,8 @@
  * Use of this source code is governed by the MIT license that can be found in the LICENSE file.
  */
 
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     id 'kotlin-multiplatform'
     id 'org.jetbrains.gradle.plugin.idea-ext'
@@ -20,9 +22,18 @@ kotlin {
 //            kotlinOptions.moduleKind = "umd"
         }
     }
-    macosX64()
-    linuxX64()
-    mingwX64()
+
+    if (project.buildSettings.build_python_extension) {
+        def currentOs = DefaultNativePlatform.getCurrentOperatingSystem()
+
+        if (currentOs.isMacOsX()) {
+            macosX64()
+        } else if (currentOs.isLinux()) {
+            linuxX64()
+        } else if (currentOs.isWindows()) {
+            mingwX64()
+        }
+    }
 
     sourceSets {
         commonMain {

--- a/plot-base-portable/build.gradle
+++ b/plot-base-portable/build.gradle
@@ -3,6 +3,8 @@
  * Use of this source code is governed by the MIT license that can be found in the LICENSE file.
  */
 
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     id 'kotlin-multiplatform'
     id 'org.jetbrains.gradle.plugin.idea-ext'
@@ -15,9 +17,18 @@ repositories {
 kotlin {
     jvm()
     js()
-    macosX64()
-    linuxX64()
-    mingwX64()
+
+    if (project.buildSettings.build_python_extension) {
+        def currentOs = DefaultNativePlatform.getCurrentOperatingSystem()
+
+        if (currentOs.isMacOsX()) {
+            macosX64()
+        } else if (currentOs.isLinux()) {
+            linuxX64()
+        } else if (currentOs.isWindows()) {
+            mingwX64()
+        }
+    }
 
     sourceSets {
         commonMain {

--- a/plot-builder-portable/build.gradle
+++ b/plot-builder-portable/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     id 'kotlin-multiplatform'
     id 'org.jetbrains.gradle.plugin.idea-ext'
@@ -10,9 +12,18 @@ repositories {
 kotlin {
     jvm()
     js()
-    macosX64()
-    linuxX64()
-    mingwX64()
+
+    if (project.buildSettings.build_python_extension) {
+        def currentOs = DefaultNativePlatform.getCurrentOperatingSystem()
+
+        if (currentOs.isMacOsX()) {
+            macosX64()
+        } else if (currentOs.isLinux()) {
+            linuxX64()
+        } else if (currentOs.isWindows()) {
+            mingwX64()
+        }
+    }
 
     sourceSets {
         commonMain {

--- a/plot-common-portable/build.gradle
+++ b/plot-common-portable/build.gradle
@@ -3,6 +3,8 @@
  * Use of this source code is governed by the MIT license that can be found in the LICENSE file.
  */
 
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     id 'kotlin-multiplatform'
     id 'org.jetbrains.gradle.plugin.idea-ext'
@@ -15,9 +17,18 @@ repositories {
 kotlin {
     jvm()
     js()
-    macosX64()
-    linuxX64()
-    mingwX64()
+
+    if (project.buildSettings.build_python_extension) {
+        def currentOs = DefaultNativePlatform.getCurrentOperatingSystem()
+
+        if (currentOs.isMacOsX()) {
+            macosX64()
+        } else if (currentOs.isLinux()) {
+            linuxX64()
+        } else if (currentOs.isWindows()) {
+            mingwX64()
+        }
+    }
 
     sourceSets {
         commonMain {

--- a/plot-config-portable/build.gradle
+++ b/plot-config-portable/build.gradle
@@ -3,6 +3,8 @@
  * Use of this source code is governed by the MIT license that can be found in the LICENSE file.
  */
 
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     id 'kotlin-multiplatform'
     id 'org.jetbrains.gradle.plugin.idea-ext'
@@ -11,9 +13,18 @@ plugins {
 kotlin {
     jvm()
     js()
-    macosX64()
-    linuxX64()
-    mingwX64()
+
+    if (project.buildSettings.build_python_extension) {
+        def currentOs = DefaultNativePlatform.getCurrentOperatingSystem()
+
+        if (currentOs.isMacOsX()) {
+            macosX64()
+        } else if (currentOs.isLinux()) {
+            linuxX64()
+        } else if (currentOs.isWindows()) {
+            mingwX64()
+        }
+    }
 
     sourceSets {
         commonMain {

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -3,6 +3,8 @@
  * Use of this source code is governed by the MIT license that can be found in the LICENSE file.
  */
 
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     id 'kotlin-multiplatform'
     id 'org.jetbrains.gradle.plugin.idea-ext'
@@ -11,9 +13,18 @@ plugins {
 kotlin {
     jvm()
     js()
-    macosX64()
-    linuxX64()
-    mingwX64()
+
+    if (project.buildSettings.build_python_extension) {
+        def currentOs = DefaultNativePlatform.getCurrentOperatingSystem()
+
+        if (currentOs.isMacOsX()) {
+            macosX64()
+        } else if (currentOs.isLinux()) {
+            linuxX64()
+        } else if (currentOs.isWindows()) {
+            mingwX64()
+        }
+    }
 
     sourceSets {
         commonMain {

--- a/vis-svg-portable/build.gradle
+++ b/vis-svg-portable/build.gradle
@@ -3,6 +3,8 @@
  * Use of this source code is governed by the MIT license that can be found in the LICENSE file.
  */
 
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     id 'kotlin-multiplatform'
     id 'org.jetbrains.gradle.plugin.idea-ext'
@@ -11,9 +13,18 @@ plugins {
 kotlin {
     jvm()
     js()
-    macosX64()
-    linuxX64()
-    mingwX64()
+
+    if (project.buildSettings.build_python_extension) {
+        def currentOs = DefaultNativePlatform.getCurrentOperatingSystem()
+
+        if (currentOs.isMacOsX()) {
+            macosX64()
+        } else if (currentOs.isLinux()) {
+            linuxX64()
+        } else if (currentOs.isWindows()) {
+            mingwX64()
+        }
+    }
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
1. Disabled cross-compilation (Linux target will not be built on Mac and Windows).
2. Disabled native targets building with `build_python_extension: no` parameter.