### PR TITLE
Remove copyProcessedResources

### DIFF
--- a/livemap-demo/build.gradle
+++ b/livemap-demo/build.gradle
@@ -131,19 +131,3 @@ idea {
         }
     }
 }
-
-/*
- * Copyright (c) 2019. JetBrains s.r.o.
- * Use of this source code is governed by the MIT license that can be found in the LICENSE file.
- */
-
-// Workaround for Idea/Gradle bug: https://youtrack.jetbrains.com/issue/KT-24463
-// MPP: Run does not add resource directory to classpath [Cannot get resource when using common module]
-//
-// JavaFX Scene mapping requires stylesheet resource URI
-task copyProcessedResources(type: Copy) {
-    from "${project.buildDir}/processedResources"
-    into "${project.buildDir}/classes/kotlin"
-}
-
-build.dependsOn += copyProcessedResources

--- a/livemap/src/jvmTest/kotlin/jetbrains/livemap/entities/regions/FragmentsRemovingSystemTest.kt
+++ b/livemap/src/jvmTest/kotlin/jetbrains/livemap/entities/regions/FragmentsRemovingSystemTest.kt
@@ -11,8 +11,6 @@ import jetbrains.livemap.fragment.FragmentsRemovingSystem
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestName
-import java.lang.annotation.Retention
-import java.lang.annotation.RetentionPolicy
 import java.lang.reflect.Method
 
 class FragmentsRemovingSystemTest : RegionsTestBase() {
@@ -71,7 +69,7 @@ class FragmentsRemovingSystemTest : RegionsTestBase() {
         } else DEFAULT_CACHE_SIZE
     }
 
-    @Retention(RetentionPolicy.RUNTIME)
+    @Retention(AnnotationRetention.RUNTIME)
     @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
     internal annotation class CacheSize(val size: Int)
     companion object {

--- a/plot-builder-portable/build.gradle
+++ b/plot-builder-portable/build.gradle
@@ -81,18 +81,3 @@ idea {
         }
     }
 }
-
-
-/*
- * Copyright (c) 2019. JetBrains s.r.o.
- * Use of this source code is governed by the MIT license that can be found in the LICENSE file.
- */
-
-// Workaround for Idea/Gradle bug: https://youtrack.jetbrains.com/issue/KT-24463
-// MPP: Run does not add resource directory to classpath [Cannot get resource when using common module]
-task copyProcessedResources(type: Copy) {
-    from "${project.buildDir}/processedResources"
-    into "${project.buildDir}/classes/kotlin"
-}
-
-build.dependsOn += copyProcessedResources

--- a/plot-builder/build.gradle
+++ b/plot-builder/build.gradle
@@ -69,21 +69,6 @@ idea {
     }
 }
 
-
-/*
- * Copyright (c) 2019. JetBrains s.r.o.
- * Use of this source code is governed by the MIT license that can be found in the LICENSE file.
- */
-
-// Workaround for Idea/Gradle bug: https://youtrack.jetbrains.com/issue/KT-24463
-// MPP: Run does not add resource directory to classpath [Cannot get resource when using common module]
-task copyProcessedResources(type: Copy) {
-    from "${project.buildDir}/processedResources"
-    into "${project.buildDir}/classes/kotlin"
-}
-
-build.dependsOn += copyProcessedResources
-
 // Fix Gradle 7 error:
 // Execution failed for task ':plot-builder:jvmJar'.
 // Entry svgMapper/jfx/plot.css is a duplicate but no duplicate handling strategy has been set.

--- a/plot-demo-common/build.gradle
+++ b/plot-demo-common/build.gradle
@@ -58,15 +58,3 @@ idea {
         }
     }
 }
-
-
-// Workaround for Idea/Gradle bug: https://youtrack.jetbrains.com/issue/KT-24463
-// MPP: Run does not add resource directory to classpath [Cannot get resource when using common module]
-// 
-// JavaFX Scene mapping requires stylesheet resource URI 
-task copyProcessedResources(type: Copy) {
-    from "${project.buildDir}/processedResources"
-    into "${project.buildDir}/classes/kotlin"
-}
-
-build.dependsOn += copyProcessedResources

--- a/plot-demo/build.gradle
+++ b/plot-demo/build.gradle
@@ -107,18 +107,6 @@ idea {
     }
 }
 
-
-// Workaround for Idea/Gradle bug: https://youtrack.jetbrains.com/issue/KT-24463
-// MPP: Run does not add resource directory to classpath [Cannot get resource when using common module]
-// 
-// JavaFX Scene mapping requires stylesheet resource URI 
-task copyProcessedResources(type: Copy) {
-    from "${project.buildDir}/processedResources"
-    into "${project.buildDir}/classes/kotlin"
-}
-
-build.dependsOn += copyProcessedResources
-
 // Fix Gradle 7 error:
 // Execution failed for task ':plot-demo:jvm*Jar'.
 // Entry diamonds.csv is a duplicate but no duplicate handling strategy has been set.

--- a/vis-demo-common/build.gradle
+++ b/vis-demo-common/build.gradle
@@ -41,22 +41,3 @@ idea {
         }
     }
 }
-
-
-/*
- * Copyright (c) 2019. JetBrains s.r.o.
- * Use of this source code is governed by the MIT license that can be found in the LICENSE file.
- */
-
-// Workaround for Idea/Gradle bug: https://youtrack.jetbrains.com/issue/KT-24463
-// MPP: Run does not add resource directory to classpath [Cannot get resource when using common module]
-// 
-// JavaFX Scene mapping requires stylesheet resource URI 
-task copyProcessedResources(type: Copy) {
-    from "${project.buildDir}/processedResources"
-    into "${project.buildDir}/classes/kotlin"
-}
-
-build.dependsOn += copyProcessedResources
-
-


### PR DESCRIPTION
copyProcessedResources is not required now: https://youtrack.jetbrains.com/issue/KTIJ-10927
Removing this tasks removes almost all gradle warnings.