### PR TITLE
Move vis-svg-mapper-batik dependency on test-common to commonTest source set

### DIFF
--- a/vis-svg-mapper-batik/build.gradle
+++ b/vis-svg-mapper-batik/build.gradle
@@ -28,7 +28,10 @@ kotlin {
                 implementation project(':mapper-core')
                 implementation project(':vis-svg-portable')
                 implementation project(':vis-svg-mapper')
-
+            }
+        }
+        commonTest {
+            dependencies {
                 implementation project(':test-common')
             }
         }


### PR DESCRIPTION
Currently vis-svg-mapper-batik has a commonMain dependency on the test-common project. When creating the shadow jar for JVM batik, this results in the jar having a service provider for `kotlin.test.AsserterContributor` with `kotlin.test.junit.JUnitContributor`. This results in errors when using the library in a project that uses a different kotlin-test implementation (such as JUnit 5).

In my case, the following error results: `java.util.ServiceConfigurationError: kotlin.test.AsserterContributor: Provider kotlin.test.junit.JUnitContributor not found`.

This patch moves the dependency to the commonTest source set, ultimately removing the service provider from the shadow jar.