### PR TITLE
Fix using of multilayer tooltip strategy

### DIFF
--- a/plot-builder-portable/src/commonMain/kotlin/jetbrains/datalore/plot/builder/interact/GeomInteractionBuilder.kt
+++ b/plot-builder-portable/src/commonMain/kotlin/jetbrains/datalore/plot/builder/interact/GeomInteractionBuilder.kt
@@ -144,7 +144,7 @@ class GeomInteractionBuilder(private val mySupportedAesList: List<Aes<*>>) {
                     constantsMap = myTooltipConstantsAesList
                 )
             }
-            myUserTooltipSpec!!.tooltipLinePatterns == null -> {
+            myUserTooltipSpec!!.useDefaultTooltips() -> {
                 // No user line patterns => use default tooltips with the given formatted valueSources
                 defaultValueSourceTooltipLines(
                     myTooltipAes,
@@ -154,7 +154,7 @@ class GeomInteractionBuilder(private val mySupportedAesList: List<Aes<*>>) {
                     myTooltipConstantsAesList
                 )
             }
-            myUserTooltipSpec!!.tooltipLinePatterns!!.isEmpty() -> {
+            myUserTooltipSpec!!.hideTooltips() -> {
                 // User list is empty => not show tooltips
                 emptyList()
             }

--- a/plot-builder-portable/src/commonMain/kotlin/jetbrains/datalore/plot/builder/tooltip/TooltipSpecification.kt
+++ b/plot-builder-portable/src/commonMain/kotlin/jetbrains/datalore/plot/builder/tooltip/TooltipSpecification.kt
@@ -25,6 +25,10 @@ class TooltipSpecification(
         }
     }
 
+    fun useDefaultTooltips() = tooltipLinePatterns == null
+
+    fun hideTooltips() = tooltipLinePatterns?.isEmpty() ?: false
+
     companion object {
         fun withoutTooltip() = TooltipSpecification(
             valueSources = emptyList(),

--- a/plot-config-portable/src/commonMain/kotlin/jetbrains/datalore/plot/config/GeomInteractionUtil.kt
+++ b/plot-config-portable/src/commonMain/kotlin/jetbrains/datalore/plot/config/GeomInteractionUtil.kt
@@ -19,17 +19,17 @@ object GeomInteractionUtil {
     internal fun configGeomTargets(
         layerConfig: LayerConfig,
         scaleMap: TypedScaleMap,
-        multilayer: Boolean,
+        multilayerWithTooltips: Boolean,
         isLiveMap: Boolean,
         theme: Theme
     ): GeomInteraction {
-        return createGeomInteractionBuilder(layerConfig, scaleMap, multilayer, isLiveMap, theme).build()
+        return createGeomInteractionBuilder(layerConfig, scaleMap, multilayerWithTooltips, isLiveMap, theme).build()
     }
 
     internal fun createGeomInteractionBuilder(
         layerConfig: LayerConfig,
         scaleMap: TypedScaleMap,
-        multilayer: Boolean,
+        multilayerWithTooltips: Boolean,
         isLiveMap: Boolean,
         theme: Theme
     ): GeomInteractionBuilder {
@@ -42,7 +42,7 @@ object GeomInteractionUtil {
             layerConfig.geomProto.renders(),
             layerConfig.geomProto.geomKind,
             layerConfig.statKind,
-            multilayer,
+            multilayerWithTooltips,
             isCrosshairEnabled
         )
         val hiddenAesList = createHiddenAesList(layerConfig, builder.getAxisFromFunctionKind) + axisWithoutTooltip
@@ -63,14 +63,15 @@ object GeomInteractionUtil {
         renders: List<Aes<*>>,
         geomKind: GeomKind,
         statKind: StatKind,
-        multilayer: Boolean,
+        multilayerWithTooltips: Boolean,
         isCrosshairEnabled: Boolean
     ): GeomInteractionBuilder {
 
         val builder = initGeomInteractionBuilder(renders, geomKind, statKind, isCrosshairEnabled)
 
-        if (multilayer && !isCrosshairEnabled) {
-            // Only these kinds of geoms should be switched to NEAREST XY strategy on a multilayer plot.
+        if (multilayerWithTooltips && !isCrosshairEnabled) {
+            // Only these kinds of geoms should be switched to NEAREST XY strategy on a multilayer plot,
+            // and tooltips should not be disabled in other layers.
             // Rect, histogram and other column alike geoms should not switch searching strategy, otherwise
             // tooltips behaviour becomes unexpected(histogram shows tooltip when cursor is close enough,
             // but not above a column).

--- a/plot-config-portable/src/commonMain/kotlin/jetbrains/datalore/plot/config/PlotConfigClientSideUtil.kt
+++ b/plot-config-portable/src/commonMain/kotlin/jetbrains/datalore/plot/config/PlotConfigClientSideUtil.kt
@@ -67,19 +67,22 @@ object PlotConfigClientSideUtil {
         for (tileDataByLayer in layersDataByTile) {
             val panelLayers = ArrayList<GeomLayer>()
 
-            val isMultilayer = tileDataByLayer.size > 1
             val isLiveMap = plotConfig.layerConfigs.any { it.geomProto.geomKind == GeomKind.LIVE_MAP }
 
             for (layerIndex in tileDataByLayer.indices) {
                 check(layerBuilders.size >= layerIndex)
 
                 if (layerBuilders.size == layerIndex) {
+                    val otherLayerWithTooltips = plotConfig.layerConfigs
+                        .filterIndexed { index, _ -> index != layerIndex }
+                        .any { !it.tooltips.hideTooltips() }
+
                     val layerConfig = plotConfig.layerConfigs[layerIndex]
                     val geomInteraction =
                         GeomInteractionUtil.configGeomTargets(
                             layerConfig,
                             plotConfig.scaleMap,
-                            isMultilayer,
+                            otherLayerWithTooltips,
                             isLiveMap,
                             plotConfig.theme
                         )

--- a/plot-config-portable/src/jvmTest/kotlin/plot/config/GeomInteractionBuilderCreationTest.kt
+++ b/plot-config-portable/src/jvmTest/kotlin/plot/config/GeomInteractionBuilderCreationTest.kt
@@ -175,7 +175,7 @@ class GeomInteractionBuilderCreationTest {
             val builder = GeomInteractionUtil.createGeomInteractionBuilder(
                 layerConfig = layerConfig,
                 scaleMap = plotConfig.scaleMap,
-                multilayer = false,
+                multilayerWithTooltips = false,
                 isLiveMap = false,
                 theme = DefaultTheme.minimal2()
             )
@@ -306,7 +306,7 @@ class GeomInteractionBuilderCreationTest {
         return GeomInteractionUtil.createGeomInteractionBuilder(
             layerConfig = layerConfig,
             scaleMap = plotConfig.scaleMap,
-            multilayer = false,
+            multilayerWithTooltips = false,
             isLiveMap = false,
             theme
         )


### PR DESCRIPTION
 The multi-layer tooltip detection strategy will only be used if more than one layer provides tooltips.