### PR TITLE
Fix `scale_continuous()` (not only for color aesthetics)

### DIFF
--- a/future_changes.md
+++ b/future_changes.md
@@ -48,3 +48,4 @@
 - scale manual: "values" parameter should accept dictionary as a value [[#882](https://github.com/JetBrains/lets-plot/issues/882)].
 - as_discrete: add 'levels' parameter [[#931](https://github.com/JetBrains/lets-plot/issues/931)].
 - Support for ordered categoricals [[#914](https://github.com/JetBrains/lets-plot/issues/914)].
+- `scale_continuous()` fails with non-color aesthetics [[#953](https://github.com/JetBrains/lets-plot/issues/953)].

--- a/future_changes.md
+++ b/future_changes.md
@@ -35,6 +35,9 @@
   See: [example notebook](https://nbviewer.jupyter.org/github/JetBrains/lets-plot/blob/master/docs/f-23f/margins.ipynb).
 
 
+- [BREAKING] `scale_continuous()`, `scale_color_continuous()`, `scale_fill_continuous()` no longer support `low` and `high` parameters.
+
+
 ### Fixed
 - Jitter reproducibility in geom_jitter, position_jitter, position_jitterdodge [[#911](https://github.com/JetBrains/lets-plot/issues/911)].
 - Facets: order = 0 doesn't work as expected [[#923](https://github.com/JetBrains/lets-plot/issues/923)].

--- a/future_changes.md
+++ b/future_changes.md
@@ -35,12 +35,6 @@
   See: [example notebook](https://nbviewer.jupyter.org/github/JetBrains/lets-plot/blob/master/docs/f-23f/margins.ipynb).
 
 
-- [BREAKING] `scale_continuous()`, `scale_color_continuous()` and `scale_fill_continuous()` are defined as default scales
-  for continuous data to adjust most common properties.
-
-  These functions no longer support `low` and `high` parameters.
-
-
 ### Fixed
 - Jitter reproducibility in geom_jitter, position_jitter, position_jitterdodge [[#911](https://github.com/JetBrains/lets-plot/issues/911)].
 - Facets: order = 0 doesn't work as expected [[#923](https://github.com/JetBrains/lets-plot/issues/923)].

--- a/future_changes.md
+++ b/future_changes.md
@@ -35,6 +35,12 @@
   See: [example notebook](https://nbviewer.jupyter.org/github/JetBrains/lets-plot/blob/master/docs/f-23f/margins.ipynb).
 
 
+- [BREAKING] `scale_continuous()`, `scale_color_continuous()` and `scale_fill_continuous()` are defined as default scales
+  for continuous data to adjust most common properties.
+
+  These functions no longer support `low` and `high` parameters.
+
+
 ### Fixed
 - Jitter reproducibility in geom_jitter, position_jitter, position_jitterdodge [[#911](https://github.com/JetBrains/lets-plot/issues/911)].
 - Facets: order = 0 doesn't work as expected [[#923](https://github.com/JetBrains/lets-plot/issues/923)].

--- a/python-package/lets_plot/plot/scale.py
+++ b/python-package/lets_plot/plot/scale.py
@@ -656,7 +656,7 @@ def scale_alpha_manual(values, name=None, breaks=None, labels=None, lablim=None,
 #
 
 def scale_continuous(aesthetic, *,
-                     low=None, high=None, name=None, breaks=None, labels=None, lablim=None,
+                     name=None, breaks=None, labels=None, lablim=None,
                      limits=None, na_value=None, guide=None, trans=None, format=None):
     """
     General purpose scale for continuous data.
@@ -720,10 +720,6 @@ def scale_continuous(aesthetic, *,
             ggsize(600, 200)
 
     """
-    if low is not None or high is not None:
-        print("WARN: using 'low' and 'high' parameters in `scale_continuous()` is deprecated.\n"
-              "      Please, use `scale_gradient()` for gradient color scales.")
-
     color_aesthetics = ['color', 'fill', 'paint_a', 'paint_b', 'paint_c']
     if isinstance(aesthetic, str):
         is_color_scale = aesthetic in color_aesthetics
@@ -732,18 +728,7 @@ def scale_continuous(aesthetic, *,
     else:
         is_color_scale = False
 
-    if is_color_scale:
-        return scale_gradient(aesthetic,
-                              low=None, high=None,
-                              name=name,
-                              breaks=breaks,
-                              labels=labels,
-                              lablim=lablim,
-                              limits=limits,
-                              na_value=na_value,
-                              guide=guide,
-                              trans=trans,
-                              format=format)
+    scale_mapper_kind = 'color_gradient' if is_color_scale else None
 
     return _scale(aesthetic,
                   name=name,
@@ -755,10 +740,12 @@ def scale_continuous(aesthetic, *,
                   na_value=na_value,
                   guide=guide,
                   trans=trans,
-                  format=format)
+                  format=format,
+                  #
+                  scale_mapper_kind=scale_mapper_kind)
 
 
-def scale_fill_continuous(low=None, high=None, name=None, breaks=None, labels=None, lablim=None,
+def scale_fill_continuous(name=None, breaks=None, labels=None, lablim=None,
                           limits=None, na_value=None, guide=None, trans=None, format=None):
     """
     Default color scale for `fill` aesthetic and continuous data.
@@ -820,7 +807,6 @@ def scale_fill_continuous(low=None, high=None, name=None, breaks=None, labels=No
 
     """
     return scale_continuous('fill',
-                            low=low, high=high,
                             name=name,
                             breaks=breaks,
                             labels=labels,
@@ -832,7 +818,7 @@ def scale_fill_continuous(low=None, high=None, name=None, breaks=None, labels=No
                             format=format)
 
 
-def scale_color_continuous(low=None, high=None, name=None, breaks=None, labels=None, lablim=None, limits=None,
+def scale_color_continuous(name=None, breaks=None, labels=None, lablim=None, limits=None,
                            na_value=None, guide=None, trans=None, format=None):
     """
     Default color scale for `color` aesthetic and continuous data.
@@ -892,7 +878,6 @@ def scale_color_continuous(low=None, high=None, name=None, breaks=None, labels=N
 
     """
     return scale_continuous('color',
-                            low=low, high=high,
                             name=name,
                             breaks=breaks,
                             labels=labels,

--- a/python-package/lets_plot/plot/scale.py
+++ b/python-package/lets_plot/plot/scale.py
@@ -656,7 +656,7 @@ def scale_alpha_manual(values, name=None, breaks=None, labels=None, lablim=None,
 #
 
 def scale_continuous(aesthetic, *,
-                     name=None, breaks=None, labels=None, lablim=None,
+                     low=None, high=None, name=None, breaks=None, labels=None, lablim=None,
                      limits=None, na_value=None, guide=None, trans=None, format=None):
     """
     General purpose scale for continuous data.
@@ -666,6 +666,10 @@ def scale_continuous(aesthetic, *,
     ----------
     aesthetic : str or list
         The name(s) of the aesthetic(s) that this scale works with.
+    low : str
+        Color for low end of gradient (actually `scale_gradient()` is used).
+    high : str
+        Color for high end of gradient (actually `scale_gradient()` is used).
     name : str
         The name of the scale - used as the axis label or the legend title.
         If None, the default, the name of the scale
@@ -703,6 +707,7 @@ def scale_continuous(aesthetic, *,
     Notes
     -----
     Define most common properties of a continuous scale for the specified aesthetics.
+    If `low` or `high` parameters are specified, the actual scale function used is `scale_gradient()`.
 
     Examples
     --------
@@ -720,6 +725,18 @@ def scale_continuous(aesthetic, *,
             ggsize(600, 200)
 
     """
+    if low is not None or high is not None:
+        return scale_gradient(aesthetic,
+                              low=low, high=high,
+                              name=name,
+                              breaks=breaks,
+                              labels=labels,
+                              lablim=lablim,
+                              limits=limits,
+                              na_value=na_value,
+                              guide=guide,
+                              trans=trans,
+                              format=format)
     return _scale(aesthetic,
                   name=name,
                   breaks=breaks,
@@ -733,13 +750,17 @@ def scale_continuous(aesthetic, *,
                   format=format)
 
 
-def scale_fill_continuous(name=None, breaks=None, labels=None, lablim=None,
+def scale_fill_continuous(low=None, high=None, name=None, breaks=None, labels=None, lablim=None,
                           limits=None, na_value=None, guide=None, trans=None, format=None):
     """
     Default color scale for `fill` aesthetic and continuous data.
 
     Parameters
     ----------
+    low : str
+        Color for low end of gradient (actually `scale_gradient()` is used).
+    high : str
+        Color for high end of gradient (actually `scale_gradient()` is used).
     name : str
         The name of the scale - used as the axis label or the legend title.
         If None, the default, the name of the scale
@@ -777,6 +798,7 @@ def scale_fill_continuous(name=None, breaks=None, labels=None, lablim=None,
     Notes
     -----
     Define most common properties of a continuous scale for `fill` aesthetic.
+    If `low` or `high` parameters are specified, the actual scale function used is `scale_gradient()` for `fill` aesthetic.
 
     Examples
     --------
@@ -795,6 +817,7 @@ def scale_fill_continuous(name=None, breaks=None, labels=None, lablim=None,
 
     """
     return scale_continuous('fill',
+                            low=low, high=high,
                             name=name,
                             breaks=breaks,
                             labels=labels,
@@ -806,13 +829,17 @@ def scale_fill_continuous(name=None, breaks=None, labels=None, lablim=None,
                             format=format)
 
 
-def scale_color_continuous(name=None, breaks=None, labels=None, lablim=None, limits=None,
+def scale_color_continuous(low=None, high=None, name=None, breaks=None, labels=None, lablim=None, limits=None,
                            na_value=None, guide=None, trans=None, format=None):
     """
     Default color scale for `color` aesthetic and continuous data.
 
     Parameters
     ----------
+    low : str
+        Color for low end of gradient (actually `scale_gradient()` is used).
+    high : str
+        Color for high end of gradient (actually `scale_gradient()` is used).
     name : str
         The name of the scale - used as the axis label or the legend title.
         If None, the default, the name of the scale
@@ -850,6 +877,7 @@ def scale_color_continuous(name=None, breaks=None, labels=None, lablim=None, lim
     Notes
     -----
     Define most common properties of a continuous scale for `color` aesthetic.
+    If `low` or `high` parameters are specified, the actual scale function used is `scale_gradient()` for `color` aesthetic.
 
     Examples
     --------
@@ -866,6 +894,7 @@ def scale_color_continuous(name=None, breaks=None, labels=None, lablim=None, lim
 
     """
     return scale_continuous('color',
+                            low=low, high=high,
                             name=name,
                             breaks=breaks,
                             labels=labels,

--- a/python-package/lets_plot/plot/scale.py
+++ b/python-package/lets_plot/plot/scale.py
@@ -652,23 +652,20 @@ def scale_alpha_manual(values, name=None, breaks=None, labels=None, lablim=None,
 
 
 #
-# Gradient (continuous) Color Scales
+# Scale for continuous data
 #
+
 def scale_continuous(aesthetic, *,
-                     low=None, high=None, name=None, breaks=None, labels=None, lablim=None,
+                     name=None, breaks=None, labels=None, lablim=None,
                      limits=None, na_value=None, guide=None, trans=None, format=None):
     """
     General purpose scale for continuous data.
-    Use it to adjust most common properties of a default scale for given aesthetic.
+    Use it to adjust most common properties of a default scale for given aesthetics.
 
     Parameters
     ----------
     aesthetic : str or list
         The name(s) of the aesthetic(s) that this scale works with.
-    low : str
-        Color for low end of gradient.
-    high : str
-        Color for high end of gradient.
     name : str
         The name of the scale - used as the axis label or the legend title.
         If None, the default, the name of the scale
@@ -705,7 +702,7 @@ def scale_continuous(aesthetic, *,
 
     Notes
     -----
-    Define smooth gradient between two colors (defined by low and high) for the specified aesthetics.
+    Define most common properties of a continuous scale for the specified aesthetics.
 
     Examples
     --------
@@ -718,7 +715,7 @@ def scale_continuous(aesthetic, *,
         x = list(range(50))
         ggplot({'x': x}, aes(x='x')) + \\
             geom_tile(aes(color='x', fill='x')) + \\
-            scale_continuous(aesthetic=['color', 'fill'], low='#1a9641', high='#d7191c') + \\
+            scale_continuous(aesthetic=['color', 'fill'], breaks=[5, 25, 45]) + \\
             coord_cartesian() + \\
             ggsize(600, 200)
 
@@ -733,11 +730,156 @@ def scale_continuous(aesthetic, *,
                   na_value=na_value,
                   guide=guide,
                   trans=trans,
-                  format=format,
-                  #
-                  low=low, high=high,
-                  scale_mapper_kind='color_gradient')
+                  format=format)
 
+
+def scale_fill_continuous(name=None, breaks=None, labels=None, lablim=None,
+                          limits=None, na_value=None, guide=None, trans=None, format=None):
+    """
+    Default color scale for `fill` aesthetic and continuous data.
+
+    Parameters
+    ----------
+    name : str
+        The name of the scale - used as the axis label or the legend title.
+        If None, the default, the name of the scale
+        is taken from the first mapping used for that aesthetic.
+    breaks : list or dict
+        A list of data values specifying the positions of ticks, or a dictionary which maps the tick labels to the breaks values.
+    labels : list of str or dict
+        A list of labels on ticks, or a dictionary which maps the breaks values to the tick labels.
+    lablim : int, default=None
+        The maximum label length (in characters) before trimming is applied.
+    limits : list
+        A numeric vector of length two providing limits of the scale.
+    na_value
+        Missing values will be replaced with this value.
+    guide
+        Guide to use for this scale. It can either be a string ('colorbar', 'legend')
+        or a call to a guide function (`guide_colorbar()`, `guide_legend()`)
+        specifying additional arguments. 'none' will hide the guide.
+    trans : {'identity', 'log10', 'log2', 'symlog', 'sqrt', 'reverse'}
+        Name of built-in transformation.
+    format : str
+        Define the format for labels on the scale. The syntax resembles Python's:
+
+        - '.2f' -> '12.45'
+        - 'Num {}' -> 'Num 12.456789'
+        - 'TTL: {.2f}$' -> 'TTL: 12.45$'
+
+        For more info see https://lets-plot.org/pages/formats.html.
+
+    Returns
+    -------
+    `FeatureSpec`
+        Scale specification.
+
+    Notes
+    -----
+    Define most common properties of a continuous scale for `fill` aesthetic.
+
+    Examples
+    --------
+    .. jupyter-execute::
+        :linenos:
+        :emphasize-lines: 6
+
+        from lets_plot import *
+        LetsPlot.setup_html()
+        x = list(range(50))
+        ggplot({'x': x}, aes(x='x')) + \\
+            geom_tile(aes(fill='x')) + \\
+            scale_fill_continuous(breaks=[5, 25, 45]) + \\
+            coord_cartesian() + \\
+            ggsize(600, 200)
+
+    """
+    return scale_continuous('fill',
+                            name=name,
+                            breaks=breaks,
+                            labels=labels,
+                            lablim=lablim,
+                            limits=limits,
+                            na_value=na_value,
+                            guide=guide,
+                            trans=trans,
+                            format=format)
+
+
+def scale_color_continuous(name=None, breaks=None, labels=None, lablim=None, limits=None,
+                           na_value=None, guide=None, trans=None, format=None):
+    """
+    Default color scale for `color` aesthetic and continuous data.
+
+    Parameters
+    ----------
+    name : str
+        The name of the scale - used as the axis label or the legend title.
+        If None, the default, the name of the scale
+        is taken from the first mapping used for that aesthetic.
+    breaks : list or dict
+        A list of data values specifying the positions of ticks, or a dictionary which maps the tick labels to the breaks values.
+    labels : list of str or dict
+        A list of labels on ticks, or a dictionary which maps the breaks values to the tick labels.
+    lablim : int, default=None
+        The maximum label length (in characters) before trimming is applied.
+    limits : list
+        A numeric vector of length two providing limits of the scale.
+    na_value
+        Missing values will be replaced with this value.
+    guide
+        Guide to use for this scale. It can either be a string ('colorbar', 'legend')
+        or a call to a guide function (`guide_colorbar()`, `guide_legend()`)
+        specifying additional arguments. 'none' will hide the guide.
+    trans : {'identity', 'log10', 'log2', 'symlog', 'sqrt', 'reverse'}
+        Name of built-in transformation.
+    format : str
+        Define the format for labels on the scale. The syntax resembles Python's:
+
+        - '.2f' -> '12.45'
+        - 'Num {}' -> 'Num 12.456789'
+        - 'TTL: {.2f}$' -> 'TTL: 12.45$'
+
+        For more info see https://lets-plot.org/pages/formats.html.
+
+    Returns
+    -------
+    `FeatureSpec`
+        Scale specification.
+
+    Notes
+    -----
+    Define most common properties of a continuous scale for `color` aesthetic.
+
+    Examples
+    --------
+    .. jupyter-execute::
+        :linenos:
+        :emphasize-lines: 6
+
+        from lets_plot import *
+        LetsPlot.setup_html()
+        x = list(range(10))
+        ggplot({'x': x, 'y': x}, aes('x', 'y')) + \\
+            geom_point(aes(color='x'), shape=1, size=5) + \\
+            scale_color_continuous(breaks=[0, 3, 6, 9])
+
+    """
+    return scale_continuous('color',
+                            name=name,
+                            breaks=breaks,
+                            labels=labels,
+                            lablim=lablim,
+                            limits=limits,
+                            na_value=na_value,
+                            guide=guide,
+                            trans=trans,
+                            format=format)
+
+
+#
+# Gradient Color Scales
+#
 
 def scale_gradient(aesthetic, *,
                    low=None, high=None, name=None, breaks=None, labels=None, lablim=None,
@@ -809,18 +951,20 @@ def scale_gradient(aesthetic, *,
             ggsize(600, 200)
 
     """
-
-    return scale_continuous(aesthetic,
-                            low=low, high=high,
-                            name=name,
-                            breaks=breaks,
-                            labels=labels,
-                            lablim=lablim,
-                            limits=limits,
-                            na_value=na_value,
-                            guide=guide,
-                            trans=trans,
-                            format=format)
+    return _scale(aesthetic,
+                  name=name,
+                  breaks=breaks,
+                  labels=labels,
+                  lablim=lablim,
+                  limits=limits,
+                  expand=None,
+                  na_value=na_value,
+                  guide=guide,
+                  trans=trans,
+                  format=format,
+                  #
+                  low=low, high=high,
+                  scale_mapper_kind='color_gradient')
 
 
 def scale_fill_gradient(low=None, high=None, name=None, breaks=None, labels=None, lablim=None,
@@ -872,7 +1016,7 @@ def scale_fill_gradient(low=None, high=None, name=None, breaks=None, labels=None
 
     Notes
     -----
-    Define smooth gradient between two colors (defined by low and high) for filling color.
+    Define smooth gradient between two colors (defined by low and high) for `fill` aesthetic.
 
     Examples
     --------
@@ -901,84 +1045,6 @@ def scale_fill_gradient(low=None, high=None, name=None, breaks=None, labels=None
                           guide=guide,
                           trans=trans,
                           format=format)
-
-
-def scale_fill_continuous(low=None, high=None, name=None, breaks=None, labels=None, lablim=None,
-                          limits=None, na_value=None, guide=None, trans=None, format=None):
-    """
-    Define smooth color gradient between two colors for `fill` aesthetic.
-
-    Parameters
-    ----------
-    low : str
-        Color for low end of gradient.
-    high : str
-        Color for high end of gradient.
-    name : str
-        The name of the scale - used as the axis label or the legend title.
-        If None, the default, the name of the scale
-        is taken from the first mapping used for that aesthetic.
-    breaks : list or dict
-        A list of data values specifying the positions of ticks, or a dictionary which maps the tick labels to the breaks values.
-    labels : list of str or dict
-        A list of labels on ticks, or a dictionary which maps the breaks values to the tick labels.
-    lablim : int, default=None
-        The maximum label length (in characters) before trimming is applied.
-    limits : list
-        A numeric vector of length two providing limits of the scale.
-    na_value
-        Missing values will be replaced with this value.
-    guide
-        Guide to use for this scale. It can either be a string ('colorbar', 'legend')
-        or a call to a guide function (`guide_colorbar()`, `guide_legend()`)
-        specifying additional arguments. 'none' will hide the guide.
-    trans : {'identity', 'log10', 'log2', 'symlog', 'sqrt', 'reverse'}
-        Name of built-in transformation.
-    format : str
-        Define the format for labels on the scale. The syntax resembles Python's:
-
-        - '.2f' -> '12.45'
-        - 'Num {}' -> 'Num 12.456789'
-        - 'TTL: {.2f}$' -> 'TTL: 12.45$'
-
-        For more info see https://lets-plot.org/pages/formats.html.
-
-    Returns
-    -------
-    `FeatureSpec`
-        Scale specification.
-
-    Notes
-    -----
-    Define smooth gradient between two colors (defined by low and high) for filling color.
-
-    Examples
-    --------
-    .. jupyter-execute::
-        :linenos:
-        :emphasize-lines: 6
-
-        from lets_plot import *
-        LetsPlot.setup_html()
-        x = list(range(50))
-        ggplot({'x': x}, aes(x='x')) + \\
-            geom_tile(aes(fill='x')) + \\
-            scale_fill_continuous(low='#1a9641', high='#d7191c') + \\
-            coord_cartesian() + \\
-            ggsize(600, 200)
-
-    """
-    return scale_continuous('fill',
-                            low=low, high=high,
-                            name=name,
-                            breaks=breaks,
-                            labels=labels,
-                            lablim=lablim,
-                            limits=limits,
-                            na_value=na_value,
-                            guide=guide,
-                            trans=trans,
-                            format=format)
 
 
 def scale_color_gradient(low=None, high=None, name=None, breaks=None, labels=None, lablim=None, limits=None,
@@ -1059,78 +1125,6 @@ def scale_color_gradient(low=None, high=None, name=None, breaks=None, labels=Non
                           guide=guide,
                           trans=trans,
                           format=format)
-
-
-def scale_color_continuous(low=None, high=None, name=None, breaks=None, labels=None, lablim=None, limits=None,
-                           na_value=None, guide=None, trans=None, format=None):
-    """
-    Define smooth color gradient between two colors for `color` aesthetic.
-
-    Parameters
-    ----------
-    low : str
-        Color for low end of gradient.
-    high : str
-        Color for high end of gradient.
-    name : str
-        The name of the scale - used as the axis label or the legend title.
-        If None, the default, the name of the scale
-        is taken from the first mapping used for that aesthetic.
-    breaks : list or dict
-        A list of data values specifying the positions of ticks, or a dictionary which maps the tick labels to the breaks values.
-    labels : list of str or dict
-        A list of labels on ticks, or a dictionary which maps the breaks values to the tick labels.
-    lablim : int, default=None
-        The maximum label length (in characters) before trimming is applied.
-    limits : list
-        A numeric vector of length two providing limits of the scale.
-    na_value
-        Missing values will be replaced with this value.
-    guide
-        Guide to use for this scale. It can either be a string ('colorbar', 'legend')
-        or a call to a guide function (`guide_colorbar()`, `guide_legend()`)
-        specifying additional arguments. 'none' will hide the guide.
-    trans : {'identity', 'log10', 'log2', 'symlog', 'sqrt', 'reverse'}
-        Name of built-in transformation.
-    format : str
-        Define the format for labels on the scale. The syntax resembles Python's:
-
-        - '.2f' -> '12.45'
-        - 'Num {}' -> 'Num 12.456789'
-        - 'TTL: {.2f}$' -> 'TTL: 12.45$'
-
-        For more info see https://lets-plot.org/pages/formats.html.
-
-    Returns
-    -------
-    `FeatureSpec`
-        Scale specification.
-
-    Examples
-    --------
-    .. jupyter-execute::
-        :linenos:
-        :emphasize-lines: 6
-
-        from lets_plot import *
-        LetsPlot.setup_html()
-        x = list(range(10))
-        ggplot({'x': x, 'y': x}, aes('x', 'y')) + \\
-            geom_point(aes(color='x'), shape=1, size=5) + \\
-            scale_color_continuous(low='#1a9641', high='#d7191c')
-
-    """
-    return scale_continuous('color',
-                            low=low, high=high,
-                            name=name,
-                            breaks=breaks,
-                            labels=labels,
-                            lablim=lablim,
-                            limits=limits,
-                            na_value=na_value,
-                            guide=guide,
-                            trans=trans,
-                            format=format)
 
 
 def scale_gradient2(aesthetic, *,
@@ -1277,7 +1271,7 @@ def scale_fill_gradient2(low=None, mid=None, high=None, midpoint=0, name=None, b
 
     Notes
     -----
-    Define diverging color gradient for filling color. Default mid point is set to white color.
+    Define diverging color gradient for `fill` aesthetic. Default mid point is set to white color.
 
     Examples
     --------
@@ -1783,7 +1777,7 @@ def scale_fill_hue(h=None, c=None, l=None, h_start=None, direction=None, name=No
 
     Notes
     -----
-    Define qualitative color scale with evenly spaced hues for filling color aesthetic.
+    Define qualitative color scale with evenly spaced hues for `fill` aesthetic.
 
     Examples
     --------
@@ -1907,7 +1901,7 @@ def scale_discrete(aesthetic, *,
                    name=None, breaks=None, labels=None, lablim=None, limits=None, na_value=None, guide=None, format=None):
     """
     General purpose scale for discrete data.
-    Use it to adjust most common properties of a default scale for given aesthetic.
+    Use it to adjust most common properties of a default scale for given aesthetics.
 
     Parameters
     ----------
@@ -1951,7 +1945,7 @@ def scale_discrete(aesthetic, *,
 
     Notes
     -----
-    Define qualitative color scale with evenly spaced hues for the specified aesthetics.
+    Define scale for discrete data to adjust properties for the specified aesthetics.
 
     Examples
     --------
@@ -1989,7 +1983,7 @@ def scale_discrete(aesthetic, *,
 def scale_fill_discrete(direction=None,
                         name=None, breaks=None, labels=None, lablim=None, limits=None, na_value=None, guide=None, format=None):
     """
-    Qualitative colors.
+    Qualitative colors scale for `fill` aesthetic.
     Defaults to the Brewer 'Set2' palette (or 'Set3' if the categories count > 8).
 
     Parameters
@@ -2032,7 +2026,7 @@ def scale_fill_discrete(direction=None,
 
     Notes
     -----
-    Define qualitative color scale with evenly spaced hues for filling color aesthetic.
+    Define qualitative color scale with evenly spaced hues for `fill` aesthetic.
 
     Examples
     --------
@@ -2057,6 +2051,7 @@ def scale_fill_discrete(direction=None,
                           name=name,
                           breaks=breaks,
                           labels=labels,
+                          lablim=lablim,
                           limits=limits,
                           na_value=na_value,
                           guide=guide,
@@ -2066,7 +2061,7 @@ def scale_fill_discrete(direction=None,
 def scale_color_discrete(direction=None,
                          name=None, breaks=None, labels=None, lablim=None, limits=None, na_value=None, guide=None, format=None):
     """
-    Qualitative colors.
+    Qualitative colors for `color` aesthetic.
     Defaults to the Brewer 'Set2' palette (or 'Set3' if the categories count > 8).
 
     Parameters
@@ -2278,7 +2273,7 @@ def scale_fill_grey(start=None, end=None, name=None, breaks=None, labels=None, l
 
     Notes
     -----
-    Define sequential grey color scale for filling color aesthetic.
+    Define sequential grey color scale for `fill` aesthetic.
 
     Examples
     --------

--- a/python-package/lets_plot/plot/scale.py
+++ b/python-package/lets_plot/plot/scale.py
@@ -666,10 +666,6 @@ def scale_continuous(aesthetic, *,
     ----------
     aesthetic : str or list
         The name(s) of the aesthetic(s) that this scale works with.
-    low : str
-        Color for low end of gradient (actually `scale_gradient()` is used).
-    high : str
-        Color for high end of gradient (actually `scale_gradient()` is used).
     name : str
         The name of the scale - used as the axis label or the legend title.
         If None, the default, the name of the scale
@@ -726,8 +722,19 @@ def scale_continuous(aesthetic, *,
 
     """
     if low is not None or high is not None:
+        print("WARN: using 'low' and 'high' parameters in `scale_continuous()` is deprecated.\n"
+              "      Please, use `scale_gradient()` for gradient color scales.")
+
+    is_color_scale = False
+    color_aesthetics = ['color', 'fill', 'paint_a', 'paint_b', 'paint_c']
+    if isinstance(aesthetic, str):
+        is_color_scale = aesthetic in color_aesthetics
+    elif isinstance(aesthetic, list):
+        is_color_scale = set(aesthetic).issubset(color_aesthetics)
+
+    if is_color_scale:
         return scale_gradient(aesthetic,
-                              low=low, high=high,
+                              low=None, high=None,
                               name=name,
                               breaks=breaks,
                               labels=labels,
@@ -737,6 +744,7 @@ def scale_continuous(aesthetic, *,
                               guide=guide,
                               trans=trans,
                               format=format)
+
     return _scale(aesthetic,
                   name=name,
                   breaks=breaks,
@@ -757,10 +765,6 @@ def scale_fill_continuous(low=None, high=None, name=None, breaks=None, labels=No
 
     Parameters
     ----------
-    low : str
-        Color for low end of gradient (actually `scale_gradient()` is used).
-    high : str
-        Color for high end of gradient (actually `scale_gradient()` is used).
     name : str
         The name of the scale - used as the axis label or the legend title.
         If None, the default, the name of the scale
@@ -836,10 +840,6 @@ def scale_color_continuous(low=None, high=None, name=None, breaks=None, labels=N
 
     Parameters
     ----------
-    low : str
-        Color for low end of gradient (actually `scale_gradient()` is used).
-    high : str
-        Color for high end of gradient (actually `scale_gradient()` is used).
     name : str
         The name of the scale - used as the axis label or the legend title.
         If None, the default, the name of the scale

--- a/python-package/lets_plot/plot/scale.py
+++ b/python-package/lets_plot/plot/scale.py
@@ -703,7 +703,6 @@ def scale_continuous(aesthetic, *,
     Notes
     -----
     Define most common properties of a continuous scale for the specified aesthetics.
-    If `low` or `high` parameters are specified, the actual scale function used is `scale_gradient()`.
 
     Examples
     --------
@@ -725,12 +724,13 @@ def scale_continuous(aesthetic, *,
         print("WARN: using 'low' and 'high' parameters in `scale_continuous()` is deprecated.\n"
               "      Please, use `scale_gradient()` for gradient color scales.")
 
-    is_color_scale = False
     color_aesthetics = ['color', 'fill', 'paint_a', 'paint_b', 'paint_c']
     if isinstance(aesthetic, str):
         is_color_scale = aesthetic in color_aesthetics
     elif isinstance(aesthetic, list):
         is_color_scale = set(aesthetic).issubset(color_aesthetics)
+    else:
+        is_color_scale = False
 
     if is_color_scale:
         return scale_gradient(aesthetic,
@@ -802,7 +802,6 @@ def scale_fill_continuous(low=None, high=None, name=None, breaks=None, labels=No
     Notes
     -----
     Define most common properties of a continuous scale for `fill` aesthetic.
-    If `low` or `high` parameters are specified, the actual scale function used is `scale_gradient()` for `fill` aesthetic.
 
     Examples
     --------
@@ -877,7 +876,6 @@ def scale_color_continuous(low=None, high=None, name=None, breaks=None, labels=N
     Notes
     -----
     Define most common properties of a continuous scale for `color` aesthetic.
-    If `low` or `high` parameters are specified, the actual scale function used is `scale_gradient()` for `color` aesthetic.
 
     Examples
     --------


### PR DESCRIPTION
`scale_continuous()` is defined as default scale for continuous data to adjust most common properties.
No longer support `low` and `high` parameters (need to use `scale_gradient()` instead).