### PR TITLE
Fix SyntaxWarning in annotation.py by escaping \

### DIFF
--- a/python-package/lets_plot/plot/annotation.py
+++ b/python-package/lets_plot/plot/annotation.py
@@ -171,7 +171,7 @@ class layer_labels(FeatureSpec):
         A '^' symbol can be escaped with a backslash, a brace character
         in the literal text - by doubling:
 
-        - 'x\^2' -> "x^2"
+        - 'x\\^2' -> "x^2"
         - '{{x}}' -> "{x}"
 
         Examples


### PR DESCRIPTION
Fixes the following `SyntaxWarning` in Python 3.12:

```
lets_plot/plot/annotation.py:148: SyntaxWarning: invalid escape sequence '\^'
  """
```