### PR TITLE
Fix: honor angle in element_text() for strip_text_x/y

### DIFF
--- a/plot-base/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/base/theme/FacetStripTheme.kt
+++ b/plot-base/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/base/theme/FacetStripTheme.kt
@@ -22,6 +22,6 @@ interface FacetStripTheme {
     fun stripTextStyle(): ThemeTextStyle
     fun stripMargins(): Thickness
     fun stripTextJustification(): TextJustification
-    fun stripAngle(): Double
+    fun stripTextAngle(): Double
     fun stripSpacing(): DoubleVector
 }

--- a/plot-base/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/base/theme/FacetStripTheme.kt
+++ b/plot-base/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/base/theme/FacetStripTheme.kt
@@ -22,5 +22,6 @@ interface FacetStripTheme {
     fun stripTextStyle(): ThemeTextStyle
     fun stripMargins(): Thickness
     fun stripTextJustification(): TextJustification
+    fun stripAngle(): Double
     fun stripSpacing(): DoubleVector
 }

--- a/plot-builder/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/builder/PlotTile.kt
+++ b/plot-builder/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/builder/PlotTile.kt
@@ -230,7 +230,7 @@ internal class PlotTile constructor(
         val labelSpec = PlotLabelSpecFactory.facetText(theme)
         val lineHeight = labelSpec.height()
         val className = if (isColumnLabel) "x" else "y"
-        val themeAngle = theme.stripAngle()
+        val themeAngle = theme.stripTextAngle()
         val defaultRotation = if (isColumnLabel) null else TextRotation.CLOCKWISE
         val rotation = if (themeAngle.isNaN()) {
             defaultRotation

--- a/plot-builder/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/builder/PlotTile.kt
+++ b/plot-builder/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/builder/PlotTile.kt
@@ -230,7 +230,16 @@ internal class PlotTile constructor(
         val labelSpec = PlotLabelSpecFactory.facetText(theme)
         val lineHeight = labelSpec.height()
         val className = if (isColumnLabel) "x" else "y"
-        val rotation = if (isColumnLabel) null else TextRotation.CLOCKWISE
+        val themeAngle = theme.stripAngle()
+        val defaultRotation = if (isColumnLabel) null else TextRotation.CLOCKWISE
+        val rotation = if (themeAngle.isNaN()) {
+            defaultRotation
+        } else when (themeAngle) {
+            90.0 -> TextRotation.CLOCKWISE
+            -90.0, 270.0 -> TextRotation.ANTICLOCKWISE
+            0.0 -> null
+            else -> defaultRotation  // Fallback for unsupported angles
+        }
 
         val lab = Label(label)
         lab.addClassName("${Style.FACET_STRIP_TEXT}-$className")
@@ -246,7 +255,11 @@ internal class PlotTile constructor(
         lab.setFontSize(lineHeight)
         lab.setLineHeight(lineHeight)
         lab.moveTo(pos)
-        rotation?.let { lab.rotate(it.angle) }
+        if (!themeAngle.isNaN() && themeAngle != 0.0) {
+            lab.rotate(themeAngle)
+        } else {
+            rotation?.let { lab.rotate(it.angle) }
+        }
 
         add(lab)
     }

--- a/plot-builder/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/builder/defaultTheme/DefaultFacetStripTheme.kt
+++ b/plot-builder/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/builder/defaultTheme/DefaultFacetStripTheme.kt
@@ -45,6 +45,11 @@ internal class DefaultFacetStripTheme(
 
     override fun stripTextJustification() = getTextJustification(getElemValue(textKey))
 
+    override fun stripAngle(): Double {
+        val elem = getElemValue(textKey)
+        return if (Elem.ANGLE in elem) getNumber(elem, Elem.ANGLE) else Double.NaN
+    }
+
     override fun stripSpacing(): DoubleVector {
         val spacingX = getNumber(listOf(FACET_STRIP_SPACING_X, FACET_STRIP_SPACING))
         val spacingY = getNumber(listOf(FACET_STRIP_SPACING_Y, FACET_STRIP_SPACING))

--- a/plot-builder/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/builder/defaultTheme/DefaultFacetStripTheme.kt
+++ b/plot-builder/src/commonMain/kotlin/org/jetbrains/letsPlot/core/plot/builder/defaultTheme/DefaultFacetStripTheme.kt
@@ -45,7 +45,7 @@ internal class DefaultFacetStripTheme(
 
     override fun stripTextJustification() = getTextJustification(getElemValue(textKey))
 
-    override fun stripAngle(): Double {
+    override fun stripTextAngle(): Double {
         val elem = getElemValue(textKey)
         return if (Elem.ANGLE in elem) getNumber(elem, Elem.ANGLE) else Double.NaN
     }


### PR DESCRIPTION
## Summary

The `angle` property of `element_text()` is currently ignored for facet strip labels (`strip_text_x`, `strip_text_y`). Other properties like `size` and `color` work correctly—only `angle` is affected.

**Root cause:** `PlotTile.addLabelElement()` hardcodes the rotation to `null` for X strips and `TextRotation.CLOCKWISE` for Y strips, never consulting the theme's angle value.

This PR:
- Adds `stripAngle()` to the `FacetStripTheme` interface
- Implements it in `DefaultFacetStripTheme` (returns `NaN` when unset, matching the `AxisTheme.labelAngle()` pattern)
- Reads the theme angle in `PlotTile.addLabelElement()`, falling back to the previous hardcoded defaults when no angle is specified

Fixes #1383.
Related: #1474 (`label_text` angle — same pattern, different theme element).

## Known limitation

The strip label **bounding box** is not yet resized to account for the new angle. For example, setting `strip_text_y = element_text(angle=0)` correctly renders horizontal text, but the strip area width is still computed using `titleSize().y` (text height), so long labels will be clipped. A follow-up change to `FacetedPlotLayout.facetLabelSize()` would be needed to swap the text dimension axes based on the configured angle. This is the same limitation that already exists for long labels with the default vertical rotation.

## Disclosure

This contribution was developed with AI assistance (Claude). The fix was tested locally by building the JS bundle (`jsBrowserProductionWebpack`) and swapping it into a Python/marimo environment to verify that `strip_text_y = element_text(angle=0)` renders horizontal labels and `angle=90` matches the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)